### PR TITLE
Reduce db queries reordering fix

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -103,3 +103,4 @@ Contributors
 - Ichim Tiberiu, 2015/01/13
 - Martin Peeters, 2015/02/21
 - Davide Moro, 2015/04/02
+- Matt Russell, 2015/09/27

--- a/kotti/resources.py
+++ b/kotti/resources.py
@@ -79,6 +79,7 @@ class ContainerMixin(object, DictMixin):
     def __setitem__(self, key, node):
         key = node.name = unicode(key)
         self.children.append(node)
+        self.children.reorder()
 
     def __delitem__(self, key):
         node = self[unicode(key)]

--- a/kotti/views/edit/actions.py
+++ b/kotti/views/edit/actions.py
@@ -145,7 +145,7 @@ class NodeActions(object):
                     item.__parent__.children.remove(item)
                     item.name = title_to_name(item.name,
                                               blacklist=self.context.keys())
-                    self.context.children.append(item)
+                    self.context[item.name] = item
                     if count is len(ids) - 1:
                         del self.request.session['kotti.paste']
                 elif action == 'copy':
@@ -155,7 +155,7 @@ class NodeActions(object):
                         name = copy.title
                     name = title_to_name(name, blacklist=self.context.keys())
                     copy.name = name
-                    self.context.children.append(copy)
+                    self.context[name] = copy
                 self.flash(_(u'${title} was pasted.',
                              mapping=dict(title=item.title)), 'success')
             else:


### PR DESCRIPTION
@disko Final change to the proposed fix for reduce-db-queries.

Based on the warning/advice given in the  [docstring](http://docs.sqlalchemy.org/en/latest/orm/extensions/orderinglist.html#sqlalchemy.ext.orderinglist.OrderingList.params.reorder_on_append) for `sqlalchemy.ext.orderinglist`, this PR removes the setting of `reorder_on_append` and replaced it with a call to `reorder()` anywhere `node.children.append` was being called.

This also passes all tests against SQLite and PostgreSQL.