### PR TITLE
remove deprecation warning (pyramid.security.has_permission)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Change History
 
 - **Python 3 compatibility**
 
+- avoid deprecation warning ``pyramid.security.has_permission``
+
 1.3.1.dev0 - unreleased
 -----------------------
 

--- a/kotti/security.py
+++ b/kotti/security.py
@@ -28,6 +28,13 @@ from kotti.util import _
 from kotti.util import request_cache
 
 
+def has_permission(permission, context, request):
+    """ Default permission checker """
+    return request.has_permission(
+        permission,
+        context=context)
+
+
 def get_principals():
     return get_settings()['kotti.principals_factory'][0]()
 

--- a/kotti/tests/test_security.py
+++ b/kotti/tests/test_security.py
@@ -5,6 +5,19 @@ from pytest import raises
 from kotti.testing import DummyRequest
 
 
+class HasPermissionTests:
+
+    def test_has_permission(self):
+        import mock
+        from kotti.security import has_permission
+        permission = 'edit'
+        context = object()
+        request = mock.MagicMock()
+        has_permission(permission, context, request)
+        assert request.has_permission.assert_called_once_with(
+            permission, context=context) is None
+
+
 class TestGroups:
     def test_root_default(self, db_session, root):
         from kotti.security import list_groups

--- a/kotti/workflow.zcml
+++ b/kotti/workflow.zcml
@@ -15,7 +15,7 @@
   <workflow name="simple" initial_state="private"
             type="security" state_attr="state"
             content_types="kotti.interfaces.IDefaultWorkflow"
-            permission_checker="pyramid.security.has_permission">
+            permission_checker="kotti.security.has_permission">
 
     <state name="private" title="Private" i18n:attributes="title"
            callback="kotti.workflow.workflow_callback">


### PR DESCRIPTION
There is a a PR on repoze.workflow but I don't know if it will be accepted:
* https://github.com/repoze/reporeze.workflow/pull/11

In the mean time here it is the removal of ``pyramid.security.has_permission`` that does not depend on external packages to be merged/released. If the repoze.workflow PR will be merged we can easily switch to the repoze.workflow's implementation of ``has_permission``